### PR TITLE
Adiciona carregamento dinâmico de QR Code para compatibilidade com S3

### DIFF
--- a/src/Gateway/PagarmePixGateway.php
+++ b/src/Gateway/PagarmePixGateway.php
@@ -11,7 +11,8 @@ use WCPagarmePixPayment\Pagarme\PagarmeApiV5;
 /**
  * Pix GeteWay class
  */
-class PagarmePixGateway extends WC_Payment_Gateway {
+class PagarmePixGateway extends WC_Payment_Gateway
+{
 
 	private static $instance;
 
@@ -62,11 +63,14 @@ class PagarmePixGateway extends WC_Payment_Gateway {
 
 	public $page_refresh;
 
+	public $save_as_base64;
+
 
 	/**
 	 * Constructor for the gateway.
 	 */
-	public function __construct() {
+	public function __construct()
+	{
 		self::$instance = $this;
 
 		global $current_section;
@@ -76,7 +80,7 @@ class PagarmePixGateway extends WC_Payment_Gateway {
 		$this->has_fields = true;
 		$this->method_title = 'Pix';
 		$this->method_description = 'Pagamento via PIX processados pela Pagarme.';
-		$this->supports = array( 'products' );
+		$this->supports = array('products');
 
 
 		// Method with all the options fields
@@ -89,37 +93,37 @@ class PagarmePixGateway extends WC_Payment_Gateway {
 		$this->setup_settings();
 
 		// Set the API.
-		if ( $this->api_version == 'v4' )
-			$this->api = new PagarmeApiV4( $this );
+		if ($this->api_version == 'v4')
+			$this->api = new PagarmeApiV4($this);
 
 		// Set the API.
-		if ( $this->api_version == 'v5' )
-			$this->api = new PagarmeApiV5( $this );
+		if ($this->api_version == 'v5')
+			$this->api = new PagarmeApiV5($this);
 
 		// Active logs.
-		if ( 'yes' === $this->debug ) {
+		if ('yes' === $this->debug) {
 			$this->log = new WC_Logger();
 		}
 
 		if (
-			isset( $_POST['pagarmeconfirm'] )
-			&& isset( $_GET['page'] )
+			isset($_POST['pagarmeconfirm'])
+			&& isset($_GET['page'])
 			&& $_GET['page'] == 'wc-settings'
-			&& isset( $_GET['section'] )
+			&& isset($_GET['section'])
 			&& $_GET['section'] == 'wc_pagarme_pix_payment_geteway'
 		) {
-			$update_settings = get_option( $this->get_option_key(), [] );
+			$update_settings = get_option($this->get_option_key(), []);
 			$update_settings['read_notice'] = true;
 			$this->read_notice = true;
-			update_option( $this->get_option_key(), apply_filters( 'woocommerce_settings_api_sanitized_fields_' . $this->id, $update_settings ), 'yes' );
+			update_option($this->get_option_key(), apply_filters('woocommerce_settings_api_sanitized_fields_' . $this->id, $update_settings), 'yes');
 		}
 
 		// Actions.
-		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
-		add_action( 'woocommerce_thankyou_' . $this->id, array( $this, 'thankyou_page' ) );
-		add_action( 'woocommerce_order_details_before_order_table', array( $this, 'order_view_page' ) );
-		add_action( 'woocommerce_email_before_order_table', array( $this, 'email_instructions' ), 10, 3 );
-		add_action( 'woocommerce_api_' . $this->id, array( $this, 'ipn_handler' ) );
+		add_action('woocommerce_update_options_payment_gateways_' . $this->id, array($this, 'process_admin_options'));
+		add_action('woocommerce_thankyou_' . $this->id, array($this, 'thankyou_page'));
+		add_action('woocommerce_order_details_before_order_table', array($this, 'order_view_page'));
+		add_action('woocommerce_email_before_order_table', array($this, 'email_instructions'), 10, 3);
+		add_action('woocommerce_api_' . $this->id, array($this, 'ipn_handler'));
 	}
 
 	/**
@@ -128,25 +132,27 @@ class PagarmePixGateway extends WC_Payment_Gateway {
 	 * @since 1.1.0
 	 * @return void|bool
 	 */
-	public function process_admin_options() {
+	public function process_admin_options()
+	{
 		$current_tab = $this->get_current_tab();
-		$update_settings = get_option( $this->get_option_key(), [] );
+		$update_settings = get_option($this->get_option_key(), []);
 
-		if ( ! is_array( $update_settings ) )
+		if (! is_array($update_settings))
 			$update_settings = [];
 
-		switch ( $current_tab ) {
+		switch ($current_tab) {
 			case 'general':
-				$title = filter_input( INPUT_POST, $this->get_field_name( 'title' ), FILTER_SANITIZE_STRING );
-				$api_key = filter_input( INPUT_POST, $this->get_field_name( 'api_key' ), FILTER_SANITIZE_STRING );
-				$api_version = filter_input( INPUT_POST, $this->get_field_name( 'api_version' ), FILTER_SANITIZE_STRING );
-				$encryption_key = filter_input( INPUT_POST, $this->get_field_name( 'encryption_key' ), FILTER_SANITIZE_STRING );
-				$secret_key = filter_input( INPUT_POST, $this->get_field_name( 'secret_key' ), FILTER_SANITIZE_STRING );
-				$debug = filter_input( INPUT_POST, $this->get_field_name( 'debug' ), FILTER_SANITIZE_STRING );
-				$after_paid_status = filter_input( INPUT_POST, $this->get_field_name( 'after_paid_status' ), FILTER_SANITIZE_STRING );
+				$title = filter_input(INPUT_POST, $this->get_field_name('title'), FILTER_SANITIZE_STRING);
+				$api_key = filter_input(INPUT_POST, $this->get_field_name('api_key'), FILTER_SANITIZE_STRING);
+				$api_version = filter_input(INPUT_POST, $this->get_field_name('api_version'), FILTER_SANITIZE_STRING);
+				$encryption_key = filter_input(INPUT_POST, $this->get_field_name('encryption_key'), FILTER_SANITIZE_STRING);
+				$secret_key = filter_input(INPUT_POST, $this->get_field_name('secret_key'), FILTER_SANITIZE_STRING);
+				$debug = filter_input(INPUT_POST, $this->get_field_name('debug'), FILTER_SANITIZE_STRING);
+				$after_paid_status = filter_input(INPUT_POST, $this->get_field_name('after_paid_status'), FILTER_SANITIZE_STRING);
+				$save_as_base64 = filter_input(INPUT_POST, $this->get_field_name('save_as_base64'), FILTER_SANITIZE_STRING);
 
-				if ( ( $api_version == 'v4' && ( empty( $api_key ) || empty( $encryption_key ) ) ) || empty( $title ) || empty( $api_version ) ) {
-					WC_Admin_Settings::add_error( __( 'É preciso preencher a todos os campos', \WC_PAGARME_PIX_PAYMENT_DIR_NAME ) );
+				if (($api_version == 'v4' && (empty($api_key) || empty($encryption_key))) || empty($title) || empty($api_version)) {
+					WC_Admin_Settings::add_error(__('É preciso preencher a todos os campos', \WC_PAGARME_PIX_PAYMENT_DIR_NAME));
 					return;
 				}
 
@@ -155,8 +161,9 @@ class PagarmePixGateway extends WC_Payment_Gateway {
 				$update_settings['title'] = $title;
 				$update_settings['encryption_key'] = $encryption_key;
 				$update_settings['secret_key'] = $secret_key;
-				$update_settings['debug'] = isset( $debug ) ? 'yes' : 'no';
+				$update_settings['debug'] = isset($debug) ? 'yes' : 'no';
 				$update_settings['after_paid_status'] = $after_paid_status;
+				$update_settings['save_as_base64'] = isset($save_as_base64) ? 'yes' : 'no';
 
 				$this->api_key = $update_settings['api_key'];
 				$this->api_version = $update_settings['api_version'];
@@ -165,16 +172,17 @@ class PagarmePixGateway extends WC_Payment_Gateway {
 				$this->secret_key = $update_settings['secret_key'];
 				$this->debug = $update_settings['debug'];
 				$this->after_paid_status = $update_settings['after_paid_status'];
+				$this->save_as_base64 = $update_settings['save_as_base64'];
 
 				break;
 			case 'customize':
-				$checkout_message = filter_input( INPUT_POST, $this->get_field_name( 'checkout_message' ) ); //Liberar HTML
-				$order_recived_message = filter_input( INPUT_POST, $this->get_field_name( 'order_recived_message' ) );
-				$thank_you_message = filter_input( INPUT_POST, $this->get_field_name( 'thank_you_message' ) );
-				$pix_icon_color = filter_input( INPUT_POST, $this->get_field_name( 'pix_icon_color' ), FILTER_SANITIZE_STRING );
-				$pix_icon_size = filter_input( INPUT_POST, $this->get_field_name( 'pix_icon_size' ), FILTER_SANITIZE_STRING );
+				$checkout_message = filter_input(INPUT_POST, $this->get_field_name('checkout_message')); //Liberar HTML
+				$order_recived_message = filter_input(INPUT_POST, $this->get_field_name('order_recived_message'));
+				$thank_you_message = filter_input(INPUT_POST, $this->get_field_name('thank_you_message'));
+				$pix_icon_color = filter_input(INPUT_POST, $this->get_field_name('pix_icon_color'), FILTER_SANITIZE_STRING);
+				$pix_icon_size = filter_input(INPUT_POST, $this->get_field_name('pix_icon_size'), FILTER_SANITIZE_STRING);
 
-				if ( empty( $checkout_message ) || empty( $order_recived_message ) || empty( $thank_you_message ) ) {
+				if (empty($checkout_message) || empty($order_recived_message) || empty($thank_you_message)) {
 					//WC_Admin_Settings::add_error( __('É preciso preencher a todos os campos', \WC_PAGARME_PIX_PAYMENT_DIR_NAME) ); 
 				}
 
@@ -192,76 +200,76 @@ class PagarmePixGateway extends WC_Payment_Gateway {
 
 				break;
 			case 'email':
-				$email_instruction = filter_input( INPUT_POST, $this->get_field_name( 'email_instruction' ) ); //Allow HTML
-				$email_instruction = preg_replace( '#<script(.*?)>(.*?)</script>#is', '', $email_instruction );
-				$email_instruction = preg_replace( '/”/', '"', $email_instruction );
+				$email_instruction = filter_input(INPUT_POST, $this->get_field_name('email_instruction')); //Allow HTML
+				$email_instruction = preg_replace('#<script(.*?)>(.*?)</script>#is', '', $email_instruction);
+				$email_instruction = preg_replace('/”/', '"', $email_instruction);
 				$update_settings['email_instruction'] = $email_instruction;
 
 				$this->email_instruction = $update_settings['email_instruction'];
 
 				break;
 			case 'advanced':
-				$check_payment_interval = filter_input( INPUT_POST, $this->get_field_name( 'check_payment_interval' ), FILTER_SANITIZE_NUMBER_INT );
-				$auto_cancel = filter_input( INPUT_POST, $this->get_field_name( 'auto_cancel' ), FILTER_SANITIZE_STRING );
-				$page_refresh = filter_input( INPUT_POST, $this->get_field_name( 'page_refresh' ), FILTER_SANITIZE_STRING );
-				$apply_discount = filter_input( INPUT_POST, $this->get_field_name( 'apply_discount' ), FILTER_SANITIZE_STRING );
-				$apply_discount_amount = filter_input( INPUT_POST, $this->get_field_name( 'apply_discount_amount' ), FILTER_UNSAFE_RAW );
-				$apply_discount_type = filter_input( INPUT_POST, $this->get_field_name( 'apply_discount_type' ), FILTER_UNSAFE_RAW );
-				$expiration_days = filter_input( INPUT_POST, $this->get_field_name( 'expiration_days' ), FILTER_VALIDATE_INT );
-				$expiration_hours = filter_input( INPUT_POST, $this->get_field_name( 'expiration_hours' ), FILTER_VALIDATE_INT );
+				$check_payment_interval = filter_input(INPUT_POST, $this->get_field_name('check_payment_interval'), FILTER_SANITIZE_NUMBER_INT);
+				$auto_cancel = filter_input(INPUT_POST, $this->get_field_name('auto_cancel'), FILTER_SANITIZE_STRING);
+				$page_refresh = filter_input(INPUT_POST, $this->get_field_name('page_refresh'), FILTER_SANITIZE_STRING);
+				$apply_discount = filter_input(INPUT_POST, $this->get_field_name('apply_discount'), FILTER_SANITIZE_STRING);
+				$apply_discount_amount = filter_input(INPUT_POST, $this->get_field_name('apply_discount_amount'), FILTER_UNSAFE_RAW);
+				$apply_discount_type = filter_input(INPUT_POST, $this->get_field_name('apply_discount_type'), FILTER_UNSAFE_RAW);
+				$expiration_days = filter_input(INPUT_POST, $this->get_field_name('expiration_days'), FILTER_VALIDATE_INT);
+				$expiration_hours = filter_input(INPUT_POST, $this->get_field_name('expiration_hours'), FILTER_VALIDATE_INT);
 
-				if ( $expiration_hours < 0 ) {
-					WC_Admin_Settings::add_error( __( 'Horas que expiram não pode ser menor que 0', \WC_PAGARME_PIX_PAYMENT_DIR_NAME ) );
+				if ($expiration_hours < 0) {
+					WC_Admin_Settings::add_error(__('Horas que expiram não pode ser menor que 0', \WC_PAGARME_PIX_PAYMENT_DIR_NAME));
 					return;
 				}
 
-				if ( $expiration_hours >= 24 ) {
-					WC_Admin_Settings::add_error( __( 'Horas que expiram não pode ser maior ou igual a 24 horas, se deseja mais que 24 horas, coloque no campo dias', \WC_PAGARME_PIX_PAYMENT_DIR_NAME ) );
+				if ($expiration_hours >= 24) {
+					WC_Admin_Settings::add_error(__('Horas que expiram não pode ser maior ou igual a 24 horas, se deseja mais que 24 horas, coloque no campo dias', \WC_PAGARME_PIX_PAYMENT_DIR_NAME));
 					return;
 				}
 
-				if ( $expiration_hours <= 0 && $expiration_days <= 0 ) {
-					WC_Admin_Settings::add_error( __( 'Coloque ao menos um campo de hora ou dias maior que 0', \WC_PAGARME_PIX_PAYMENT_DIR_NAME ) );
+				if ($expiration_hours <= 0 && $expiration_days <= 0) {
+					WC_Admin_Settings::add_error(__('Coloque ao menos um campo de hora ou dias maior que 0', \WC_PAGARME_PIX_PAYMENT_DIR_NAME));
 					return;
 				}
 
-				if ( $expiration_days < 0 ) {
-					WC_Admin_Settings::add_error( __( 'Dias de expiração não pode ser menor que zero', \WC_PAGARME_PIX_PAYMENT_DIR_NAME ) );
+				if ($expiration_days < 0) {
+					WC_Admin_Settings::add_error(__('Dias de expiração não pode ser menor que zero', \WC_PAGARME_PIX_PAYMENT_DIR_NAME));
 					return;
 				}
 
-				if ( $expiration_days === '' ) {
-					WC_Admin_Settings::add_error( __( 'É preciso preencher o compo de dias da expiração', \WC_PAGARME_PIX_PAYMENT_DIR_NAME ) );
+				if ($expiration_days === '') {
+					WC_Admin_Settings::add_error(__('É preciso preencher o compo de dias da expiração', \WC_PAGARME_PIX_PAYMENT_DIR_NAME));
 					return;
 				}
 
-				if ( $check_payment_interval <= 4 ) {
-					WC_Admin_Settings::add_error( __( 'O intervalo não pode ser menor que 5 segundos para evitar sobrecarga.', \WC_PAGARME_PIX_PAYMENT_DIR_NAME ) );
+				if ($check_payment_interval <= 4) {
+					WC_Admin_Settings::add_error(__('O intervalo não pode ser menor que 5 segundos para evitar sobrecarga.', \WC_PAGARME_PIX_PAYMENT_DIR_NAME));
 					return;
 				}
 
-				if ( isset( $apply_discount ) && ( empty( $apply_discount_amount ) || empty( $apply_discount_type ) ) ) {
-					WC_Admin_Settings::add_error( __( 'Ao ativar o desconto você precisa preencher os campos.', \WC_PAGARME_PIX_PAYMENT_DIR_NAME ) );
+				if (isset($apply_discount) && (empty($apply_discount_amount) || empty($apply_discount_type))) {
+					WC_Admin_Settings::add_error(__('Ao ativar o desconto você precisa preencher os campos.', \WC_PAGARME_PIX_PAYMENT_DIR_NAME));
 					return;
 				}
 
-				if ( isset( $apply_discount ) && $apply_discount_amount == '0' ) {
-					WC_Admin_Settings::add_error( __( 'O desconto não pode ser 0.', \WC_PAGARME_PIX_PAYMENT_DIR_NAME ) );
+				if (isset($apply_discount) && $apply_discount_amount == '0') {
+					WC_Admin_Settings::add_error(__('O desconto não pode ser 0.', \WC_PAGARME_PIX_PAYMENT_DIR_NAME));
 					return;
 				}
 
-				if ( isset( $apply_discount ) && ! preg_match( '/^[0-9]+([\,][0-9]{1,2})?$/i', $apply_discount_amount ) ) {
-					WC_Admin_Settings::add_error( __( 'O desconto só poder ter números inteiros ou então separado por "," (vírgula) com até 2 casas decimais: ex: 10 ou 5,80', \WC_PAGARME_PIX_PAYMENT_DIR_NAME ) );
+				if (isset($apply_discount) && ! preg_match('/^[0-9]+([\,][0-9]{1,2})?$/i', $apply_discount_amount)) {
+					WC_Admin_Settings::add_error(__('O desconto só poder ter números inteiros ou então separado por "," (vírgula) com até 2 casas decimais: ex: 10 ou 5,80', \WC_PAGARME_PIX_PAYMENT_DIR_NAME));
 					return;
 				}
 
-				$apply_discount_amount = preg_replace( '/,/i', '.', $apply_discount_amount );
+				$apply_discount_amount = preg_replace('/,/i', '.', $apply_discount_amount);
 
 
 				$update_settings['check_payment_interval'] = $check_payment_interval;
-				$update_settings['auto_cancel'] = isset( $auto_cancel ) ? 'yes' : 'no';
-				$update_settings['page_refresh'] = isset( $page_refresh ) ? 'yes' : 'no';
-				$update_settings['apply_discount'] = isset( $apply_discount ) ? 'yes' : 'no';
+				$update_settings['auto_cancel'] = isset($auto_cancel) ? 'yes' : 'no';
+				$update_settings['page_refresh'] = isset($page_refresh) ? 'yes' : 'no';
+				$update_settings['apply_discount'] = isset($apply_discount) ? 'yes' : 'no';
 				$update_settings['apply_discount_amount'] = $apply_discount_amount;
 				$update_settings['apply_discount_type'] = $apply_discount_type;
 				$update_settings['expiration_days'] = $expiration_days;
@@ -279,7 +287,7 @@ class PagarmePixGateway extends WC_Payment_Gateway {
 				break;
 		}
 
-		update_option( $this->get_option_key(), apply_filters( 'woocommerce_settings_api_sanitized_fields_' . $this->id, $update_settings ) );
+		update_option($this->get_option_key(), apply_filters('woocommerce_settings_api_sanitized_fields_' . $this->id, $update_settings));
 		$this->init_settings();
 		$this->setup_settings();
 	}
@@ -290,57 +298,58 @@ class PagarmePixGateway extends WC_Payment_Gateway {
 	 * @since 1.1.0
 	 * @return void
 	 */
-	public function init_form_fields() {
+	public function init_form_fields()
+	{
 		$this->form_fields = array(
 			'title' => array(
-				'title' => __( 'Titulo', 'wc-pagarme-pix-payment' ),
+				'title' => __('Titulo', 'wc-pagarme-pix-payment'),
 				'type' => 'text',
-				'description' => __( 'Esse titulo irá aparecer na opção de pagamento para o cliente', 'wc-pagarme-pix-payment' ),
+				'description' => __('Esse titulo irá aparecer na opção de pagamento para o cliente', 'wc-pagarme-pix-payment'),
 				'default' => '',
 				'custom_attributes' => array(
 					'required' => 'required',
 				),
 			),
 			'api_version' => array(
-				'title' => __( 'Pagar.me Versão API', 'wc-pagarme-pix-payment' ),
+				'title' => __('Pagar.me Versão API', 'wc-pagarme-pix-payment'),
 				'type' => 'select',
-				'description' => __( 'Insira a versão da API da pagar.me que você está usando', 'wc-pagarme-pix-payment' ),
+				'description' => __('Insira a versão da API da pagar.me que você está usando', 'wc-pagarme-pix-payment'),
 				'default' => 'v4',
-				'options' => array( 'v4' => 'v4 (01/09/2019)', 'v5' => 'v5 (stable)' ),
+				'options' => array('v4' => 'v4 (01/09/2019)', 'v5' => 'v5 (stable)'),
 				'custom_attributes' => array(
 					'required' => 'required',
 				),
 			),
 			'api_key' => array(
-				'title' => __( 'Pagar.me API Key', 'wc-pagarme-pix-payment' ),
+				'title' => __('Pagar.me API Key', 'wc-pagarme-pix-payment'),
 				'type' => 'text',
-				'description' => sprintf( __( 'Insira a Pagar.me API Key. Caso você não saiba você pode obter em %s.', 'wc-pagarme-pix-payment' ), '<a href="https://dashboard.pagar.me/">' . __( 'Pagar.me Dashboard > My Account page', 'wc-pagarme-pix-payment' ) . '</a>' ),
+				'description' => sprintf(__('Insira a Pagar.me API Key. Caso você não saiba você pode obter em %s.', 'wc-pagarme-pix-payment'), '<a href="https://dashboard.pagar.me/">' . __('Pagar.me Dashboard > My Account page', 'wc-pagarme-pix-payment') . '</a>'),
 				'default' => '',
 				'custom_attributes' => array(
 					'required' => 'required',
 				),
 			),
 			'encryption_key' => array(
-				'title' => __( 'Pagar.me Encryption Key', 'wc-pagarme-pix-payment' ),
+				'title' => __('Pagar.me Encryption Key', 'wc-pagarme-pix-payment'),
 				'type' => 'text',
-				'description' => sprintf( __( 'Insira a Pagar.me Encryption key. Caso você não saiba você pode obter em %s.', 'wc-pagarme-pix-payment' ), '<a href="https://dashboard.pagar.me/">' . __( 'Pagar.me Dashboard > My Account page', 'wc-pagarme-pix-payment' ) . '</a>' ),
+				'description' => sprintf(__('Insira a Pagar.me Encryption key. Caso você não saiba você pode obter em %s.', 'wc-pagarme-pix-payment'), '<a href="https://dashboard.pagar.me/">' . __('Pagar.me Dashboard > My Account page', 'wc-pagarme-pix-payment') . '</a>'),
 				'default' => '',
 				'custom_attributes' => array(
 					'required' => 'required',
 				),
 			),
 			'secret_key' => array(
-				'title' => __( 'Pagar.me Secret Key', 'wc-pagarme-pix-payment' ),
+				'title' => __('Pagar.me Secret Key', 'wc-pagarme-pix-payment'),
 				'type' => 'text',
-				'description' => sprintf( __( 'Insira a Chave Secreta. Caso você não saiba você pode obter em %s.<br><br><strong style="color: red">Importante!</strong><p>1) É necessário o plugin <a href="https://br.wordpress.org/plugins/woocommerce-extra-checkout-fields-for-brazil/">Brazilian Market on WooCommerce</a> pois o campo CPF é obrigatório na api v5</p><p>2) Para a detecção automatica de pagamento, você precisa configurar a seguinte Webhook na dashboard Pagar.me:</p><br>Dashboard -> Configurações -> Webhooks -> (+ Criar Webhook) -> Eventos -> Cobrança -> Marcar: \'charge.paid\' e adicionar URL abaixo: <br><div class="mgn-webhook-box"><strong>%s</strong></div>', 'wc-pagarme-pix-payment' ), '<a href="https://dash.pagar.me/">' . __( 'Pagar.me Dashboard > Desenvolvimento > Chaves', 'wc-pagarme-pix-payment' ) . '</a>', WC()->api_request_url( $this->id ) ),
+				'description' => sprintf(__('Insira a Chave Secreta. Caso você não saiba você pode obter em %s.<br><br><strong style="color: red">Importante!</strong><p>1) É necessário o plugin <a href="https://br.wordpress.org/plugins/woocommerce-extra-checkout-fields-for-brazil/">Brazilian Market on WooCommerce</a> pois o campo CPF é obrigatório na api v5</p><p>2) Para a detecção automatica de pagamento, você precisa configurar a seguinte Webhook na dashboard Pagar.me:</p><br>Dashboard -> Configurações -> Webhooks -> (+ Criar Webhook) -> Eventos -> Cobrança -> Marcar: \'charge.paid\' e adicionar URL abaixo: <br><div class="mgn-webhook-box"><strong>%s</strong></div>', 'wc-pagarme-pix-payment'), '<a href="https://dash.pagar.me/">' . __('Pagar.me Dashboard > Desenvolvimento > Chaves', 'wc-pagarme-pix-payment') . '</a>', WC()->api_request_url($this->id)),
 				'default' => '',
 				'placeholder' => 'sk_##############',
 				'custom_attributes' => array(),
 			),
 			'after_paid_status' => array(
-				'title' => __( 'Após pagamento mudar status para:', 'wc-pagarme-pix-payment' ),
+				'title' => __('Após pagamento mudar status para:', 'wc-pagarme-pix-payment'),
 				'type' => 'select',
-				'description' => __( 'Defina o status que o pedido ficará após o pagamento ser confirmado.', 'wc-pagarme-pix-payment' ),
+				'description' => __('Defina o status que o pedido ficará após o pagamento ser confirmado.', 'wc-pagarme-pix-payment'),
 				'default' => '',
 				'options' => wc_get_order_statuses(),
 				'custom_attributes' => array(
@@ -348,12 +357,19 @@ class PagarmePixGateway extends WC_Payment_Gateway {
 				),
 			),
 			'debug' => array(
-				'title' => __( 'Debug Log', 'wc-pagarme-pix-payment' ),
+				'title' => __('Debug Log', 'wc-pagarme-pix-payment'),
 				'type' => 'checkbox',
-				'label' => __( 'Ativar logs', 'wc-pagarme-pix-payment' ),
+				'label' => __('Ativar logs', 'wc-pagarme-pix-payment'),
 				'default' => 'no',
-				'description' => sprintf( __( 'Veja os logs do plugin e mensagens de depuração em %s', 'wc-pagarme-pix-payment' ), '<a href="' . esc_url( admin_url( 'admin.php?page=wc-status&tab=logs&log_file=' . esc_attr( $this->id ) . '-' . sanitize_file_name( wp_hash( $this->id ) ) . '.log' ) ) . '">' . __( 'System Status &gt; Logs', 'wc-pagarme-pix-payment' ) . '</a>' ),
-			)
+				'description' => sprintf(__('Veja os logs do plugin e mensagens de depuração em %s', 'wc-pagarme-pix-payment'), '<a href="' . esc_url(admin_url('admin.php?page=wc-status&tab=logs&log_file=' . esc_attr($this->id) . '-' . sanitize_file_name(wp_hash($this->id)) . '.log')) . '">' . __('System Status &gt; Logs', 'wc-pagarme-pix-payment') . '</a>'),
+			),
+			'save_as_base64' => array(
+				'title' => __('Salvar QR Code como Base64', 'wc-pagarme-pix-payment'),
+				'type' => 'checkbox',
+				'label' => __('Salvar QR Code como Base64', 'wc-pagarme-pix-payment'),
+				'default' => 'no',
+				'description' => __('Salva o QR Code como base64 na página do pedido.', 'wc-pagarme-pix-payment'),
+			),
 		);
 	}
 
@@ -363,33 +379,35 @@ class PagarmePixGateway extends WC_Payment_Gateway {
 	 * @since 1.0.0
 	 * @return void
 	 */
-	public function setup_settings() {
+	public function setup_settings()
+	{
 		// Define user set variables.
-		$this->title = $this->get_option( 'title', 'Pix Instantâneo' );
-		$this->description = $this->get_option( 'description' );
-		$this->debug = $this->get_option( 'debug' );
-		$this->async = $this->get_option( 'async' );
-		$this->api_version = $this->get_option( 'api_version', 'v4' );
-		$this->api_key = $this->get_option( 'api_key' );
-		$this->encryption_key = $this->get_option( 'encryption_key' );
-		$this->secret_key = $this->get_option( 'secret_key' );
-		$this->checkout_message = $this->get_option( 'checkout_message', "Ao finalizar a compra, iremos gerar o código Pix para pagamento.\r\n\r\nNosso sistema detecta automaticamente o pagamento sem precisar enviar comprovantes." );
-		$this->order_recived_message = $this->get_option( 'order_recived_message', '<h4 style="text-align: center;">Faça o pagamento para finalizar!</h4><p style="text-align: center;">Escaneie o código QR ou copie o código abaixo para fazer o PIX.<br>O sistema vai detectar automáticamente quando fizer a transferência.</p><p style="text-align: center;"><strong>Podemos demorar até 5 minutos para detectarmos o pagamento.</strong></p><p style="text-align: center;">[copy_button]</p><p style="text-align: center;">[qr_code]</p>' );
-		$this->thank_you_message = $this->get_option( 'thank_you_message', '<p style="text-align: center;">Sua transferência PIX foi confirmada!<br>O seu pedido já está sendo separado e logo será enviado para seu endereço.</p>' );
-		$this->email_instruction = $this->get_option( 'email_instruction', '<h4 style="text-align: center;">Faça o pagamento para finalizar a compra</h4><p style="text-align: center;">Escaneie o código abaixo</p><p style="text-align: center;">[qr_code]</p><h4 style="text-align: center;">ou</h4><p style="text-align: center;">[link text="Clique aqui"] para ver o código ou copiar</p>' );
-		$this->pix_icon_color = $this->get_option( 'pix_icon_color', '#32BCAD' );
-		$this->pix_icon_size = $this->get_option( 'pix_icon_size', '48' );
-		$this->icon = apply_filters( 'woocommerce_gateway_icon', \WC_PAGARME_PIX_PAYMENT_PLUGIN_URL . 'assets/images/pix-payment-icon-32x32.svg', 'polopagpayments' );
-		$this->expiration_days = (int) $this->get_option( 'expiration_days', 15 );
-		$this->expiration_hours = (int) $this->get_option( 'expiration_hours', 0 );
-		$this->after_paid_status = $this->get_option( 'after_paid_status', 'wc-processing' );
-		$this->read_notice = $this->get_option( 'read_notice', false );
-		$this->check_payment_interval = $this->get_option( 'check_payment_interval', '5' );
-		$this->auto_cancel = $this->get_option( 'auto_cancel', 'no' );
-		$this->page_refresh = $this->get_option( 'page_refresh', 'no' );
-		$this->apply_discount = $this->get_option( 'apply_discount', 'no' );
-		$this->apply_discount_type = $this->get_option( 'apply_discount_type', 'fixed' );
-		$this->apply_discount_amount = $this->get_option( 'apply_discount_amount', '0' );
+		$this->title = $this->get_option('title', 'Pix Instantâneo');
+		$this->description = $this->get_option('description');
+		$this->debug = $this->get_option('debug');
+		$this->save_as_base64 = $this->get_option('save_as_base64');
+		$this->async = $this->get_option('async');
+		$this->api_version = $this->get_option('api_version', 'v4');
+		$this->api_key = $this->get_option('api_key');
+		$this->encryption_key = $this->get_option('encryption_key');
+		$this->secret_key = $this->get_option('secret_key');
+		$this->checkout_message = $this->get_option('checkout_message', "Ao finalizar a compra, iremos gerar o código Pix para pagamento.\r\n\r\nNosso sistema detecta automaticamente o pagamento sem precisar enviar comprovantes.");
+		$this->order_recived_message = $this->get_option('order_recived_message', '<h4 style="text-align: center;">Faça o pagamento para finalizar!</h4><p style="text-align: center;">Escaneie o código QR ou copie o código abaixo para fazer o PIX.<br>O sistema vai detectar automáticamente quando fizer a transferência.</p><p style="text-align: center;"><strong>Podemos demorar até 5 minutos para detectarmos o pagamento.</strong></p><p style="text-align: center;">[copy_button]</p><p style="text-align: center;">[qr_code]</p>');
+		$this->thank_you_message = $this->get_option('thank_you_message', '<p style="text-align: center;">Sua transferência PIX foi confirmada!<br>O seu pedido já está sendo separado e logo será enviado para seu endereço.</p>');
+		$this->email_instruction = $this->get_option('email_instruction', '<h4 style="text-align: center;">Faça o pagamento para finalizar a compra</h4><p style="text-align: center;">Escaneie o código abaixo</p><p style="text-align: center;">[qr_code]</p><h4 style="text-align: center;">ou</h4><p style="text-align: center;">[link text="Clique aqui"] para ver o código ou copiar</p>');
+		$this->pix_icon_color = $this->get_option('pix_icon_color', '#32BCAD');
+		$this->pix_icon_size = $this->get_option('pix_icon_size', '48');
+		$this->icon = apply_filters('woocommerce_gateway_icon', \WC_PAGARME_PIX_PAYMENT_PLUGIN_URL . 'assets/images/pix-payment-icon-32x32.svg', 'polopagpayments');
+		$this->expiration_days = (int) $this->get_option('expiration_days', 15);
+		$this->expiration_hours = (int) $this->get_option('expiration_hours', 0);
+		$this->after_paid_status = $this->get_option('after_paid_status', 'wc-processing');
+		$this->read_notice = $this->get_option('read_notice', false);
+		$this->check_payment_interval = $this->get_option('check_payment_interval', '5');
+		$this->auto_cancel = $this->get_option('auto_cancel', 'no');
+		$this->page_refresh = $this->get_option('page_refresh', 'no');
+		$this->apply_discount = $this->get_option('apply_discount', 'no');
+		$this->apply_discount_type = $this->get_option('apply_discount_type', 'fixed');
+		$this->apply_discount_amount = $this->get_option('apply_discount_amount', '0');
 	}
 
 	/**
@@ -398,7 +416,8 @@ class PagarmePixGateway extends WC_Payment_Gateway {
 	 * @since 1.1.0
 	 * @return string
 	 */
-	protected function get_field_name( string $field = '' ) {
+	protected function get_field_name(string $field = '')
+	{
 		return 'woocommerce_' . $this->id . '_' . $field;
 	}
 
@@ -408,9 +427,10 @@ class PagarmePixGateway extends WC_Payment_Gateway {
 	 * @since 1.1.0
 	 * @return string
 	 */
-	protected function get_current_tab() {
-		$current_tab = filter_input( INPUT_GET, 'mgn_tab', FILTER_SANITIZE_STRING );
-		$current_tab = isset( $current_tab ) ? $current_tab : 'general';
+	protected function get_current_tab()
+	{
+		$current_tab = filter_input(INPUT_GET, 'mgn_tab', FILTER_SANITIZE_STRING);
+		$current_tab = isset($current_tab) ? $current_tab : 'general';
 
 		return $current_tab;
 	}
@@ -421,10 +441,11 @@ class PagarmePixGateway extends WC_Payment_Gateway {
 	 * @since 1.1.0
 	 * @return string
 	 */
-	protected function get_current_tab_name() {
+	protected function get_current_tab_name()
+	{
 		$tabs = $this->get_tabs();
 
-		return $tabs[ $this->get_current_tab()];
+		return $tabs[$this->get_current_tab()];
 	}
 
 	/**
@@ -433,44 +454,47 @@ class PagarmePixGateway extends WC_Payment_Gateway {
 	 * @since 1.1.0
 	 * @return array
 	 */
-	protected function get_tabs() {
-		return [ 
-			'general' => __( 'Geral', 'wc-pagarme-pix-payment' ),
-			'customize' => __( 'Customizar', 'wc-pagarme-pix-payment' ),
-			'email' => __( 'E-mail', 'wc-pagarme-pix-payment' ),
-			'advanced' => __( 'Avançado', 'wc-pagarme-pix-payment' ),
-			'donate' => __( 'Doação', 'wc-pagarme-pix-payment' )
+	protected function get_tabs()
+	{
+		return [
+			'general' => __('Geral', 'wc-pagarme-pix-payment'),
+			'customize' => __('Customizar', 'wc-pagarme-pix-payment'),
+			'email' => __('E-mail', 'wc-pagarme-pix-payment'),
+			'advanced' => __('Avançado', 'wc-pagarme-pix-payment'),
+			'donate' => __('Doação', 'wc-pagarme-pix-payment')
 		];
 	}
 
 	/**
 	 * Admin page settings.
 	 */
-	public function admin_options() {
-		$baseUrl = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . $this->id );
+	public function admin_options()
+	{
+		$baseUrl = admin_url('admin.php?page=wc-settings&tab=checkout&section=' . $this->id);
 
 		$current_tab = $this->get_current_tab();
 		$current_tab_name = $this->get_current_tab_name();
 
 		$tab_template = \WC_PAGARME_PIX_PAYMENT_PLUGIN_PATH . 'templates/admin/settings/' . $current_tab . '-settings.php';
 
-		require_once ( \WC_PAGARME_PIX_PAYMENT_PLUGIN_PATH . 'templates/admin/settings/header-settings.php' );
+		require_once(\WC_PAGARME_PIX_PAYMENT_PLUGIN_PATH . 'templates/admin/settings/header-settings.php');
 
-		if ( file_exists( $tab_template ) )
-			require_once ( $tab_template );
+		if (file_exists($tab_template))
+			require_once($tab_template);
 	}
 
 	/**
 	 * Payment fields.
 	 */
-	public function payment_fields() {
-		if ( $description = $this->get_description() ) {
-			echo wp_kses_post( wpautop( wptexturize( $description ) ) );
+	public function payment_fields()
+	{
+		if ($description = $this->get_description()) {
+			echo wp_kses_post(wpautop(wptexturize($description)));
 		}
 
 		wc_get_template(
 			'html-woocommerce-instructions.php',
-			[ 
+			[
 				'description' => $this->get_description(),
 				'checkout_message' => $this->checkout_message
 			],
@@ -486,8 +510,9 @@ class PagarmePixGateway extends WC_Payment_Gateway {
 	 *
 	 * @return array Redirect data.
 	 */
-	public function process_payment( $order_id ) {
-		return $this->api->process_regular_payment( $order_id );
+	public function process_payment($order_id)
+	{
+		return $this->api->process_regular_payment($order_id);
 	}
 
 	/**
@@ -495,15 +520,16 @@ class PagarmePixGateway extends WC_Payment_Gateway {
 	 *
 	 * @param int $order_id Order ID.
 	 */
-	public function thankyou_page( $order_id ) {
-		$order = wc_get_order( $order_id );
-		$qr_code = $order->get_meta( '_wc_pagarme_pix_payment_qr_code' );
-		$expiration_date = $order->get_meta( '_wc_pagarme_pix_payment_expiration_date' );
-		$qr_code_image = $order->get_meta( '_wc_pagarme_pix_payment_qr_code_image' );
+	public function thankyou_page($order_id)
+	{
+		$order = wc_get_order($order_id);
+		$qr_code = $order->get_meta('_wc_pagarme_pix_payment_qr_code');
+		$expiration_date = $order->get_meta('_wc_pagarme_pix_payment_expiration_date');
+		$qr_code_image = $order->get_meta('_wc_pagarme_pix_payment_qr_code_image');
 
 		wc_get_template(
 			'html-woocommerce-thank-you-page.php',
-			[ 
+			[
 				'qr_code' => $qr_code,
 				'thank_you_message' => $this->thank_you_message,
 				'order_recived_message' => $this->order_recived_message,
@@ -523,13 +549,14 @@ class PagarmePixGateway extends WC_Payment_Gateway {
 	 * @since 1.1.0
 	 * @return void
 	 */
-	public function order_view_page( $order ) {
+	public function order_view_page($order)
+	{
 		if (
 			$order->get_status() == 'on-hold' &&
 			$order->get_payment_method() == $this->id &&
-			is_wc_endpoint_url( 'view-order' )
+			is_wc_endpoint_url('view-order')
 		) {
-			do_action( 'woocommerce_thankyou_' . $order->get_payment_method(), $order->get_id() );
+			do_action('woocommerce_thankyou_' . $order->get_payment_method(), $order->get_id());
 		}
 	}
 
@@ -542,9 +569,10 @@ class PagarmePixGateway extends WC_Payment_Gateway {
 	 *
 	 * @return string|void                Payment instructions.
 	 */
-	public function email_instructions( $order, $sent_to_admin, $plain_text = false ) {
+	public function email_instructions($order, $sent_to_admin, $plain_text = false)
+	{
 		if (
-			! in_array( $order->get_status(), array( 'on-hold' ), true ) ||
+			! in_array($order->get_status(), array('on-hold'), true) ||
 			$this->id !== $order->payment_method
 		) {
 			return;
@@ -552,13 +580,13 @@ class PagarmePixGateway extends WC_Payment_Gateway {
 
 		$email_type = $plain_text ? 'plain' : 'html';
 
-		$qr_code = $order->get_meta( '_wc_pagarme_pix_payment_qr_code' );
-		$expiration_date = $order->get_meta( '_wc_pagarme_pix_payment_expiration_date' );
-		$qr_code_image = $order->get_meta( '_wc_pagarme_pix_payment_qr_code_image' );
+		$qr_code = $order->get_meta('_wc_pagarme_pix_payment_qr_code');
+		$expiration_date = $order->get_meta('_wc_pagarme_pix_payment_expiration_date');
+		$qr_code_image = $order->get_meta('_wc_pagarme_pix_payment_qr_code_image');
 
 		wc_get_template(
 			'email-new-order-instructions.php',
-			[ 
+			[
 				'qr_code' => $qr_code,
 				'qr_code_image' => $qr_code_image,
 				'email_instruction' => $this->email_instruction,
@@ -575,19 +603,30 @@ class PagarmePixGateway extends WC_Payment_Gateway {
 	/**
 	 * Is Debug function
 	 */
-	public function is_debug() {
+	public function is_debug()
+	{
 		return 'yes' === $this->debug ? true : false;
+	}
+
+	/**
+	 * Is Save as Base64 function
+	 */
+	public function is_save_as_base64()
+	{
+		return 'yes' === $this->save_as_base64 ? true : false;
 	}
 
 	/**
 	 * IPN handler.
 	 */
-	public function ipn_handler() {
+	public function ipn_handler()
+	{
 		$this->api->ipn_handler();
 	}
 
-	public static function getInstance() {
-		if ( self::$instance === null ) {
+	public static function getInstance()
+	{
+		if (self::$instance === null) {
 			self::$instance = new self();
 		}
 		return self::$instance;

--- a/src/Pagarme/PagarmeApiV5.php
+++ b/src/Pagarme/PagarmeApiV5.php
@@ -3,17 +3,20 @@
 namespace WCPagarmePixPayment\Pagarme;
 
 use chillerlan\QRCode\QRCode;
+use chillerlan\QRCode\QROptions;
 
-class PagarmeApiV5 extends PagarmeApi {
+class PagarmeApiV5 extends PagarmeApi
+{
 	protected $api_url = 'https://api.pagar.me/core/v5/';
 
 	protected $endpoint = 'orders/';
 
-	public function __construct( $gateway = null ) {
+	public function __construct($gateway = null)
+	{
 		$this->gateway = $gateway;
 
-		$this->headers = [ 
-			'Authorization' => 'Basic ' . base64_encode( "{$gateway->secret_key}:" ),
+		$this->headers = [
+			'Authorization' => 'Basic ' . base64_encode("{$gateway->secret_key}:"),
 			'Content-Type' => 'application/json',
 			'Accept' => 'application/json'
 		];
@@ -26,153 +29,155 @@ class PagarmeApiV5 extends PagarmeApi {
 	 *
 	 * @return array|null Transaction data.
 	 */
-	public function generate_transaction_data( $order ) {
+	public function generate_transaction_data($order)
+	{
 		// Set the request data.
 		$data = array(
-			'metadata' => [ 
+			'metadata' => [
 				'order_number' => $order->get_order_number(),
 			],
-			'items' => [ 
-				[ 
-					'amount' => round( $order->get_total() * 100 ),
+			'items' => [
+				[
+					'amount' => round($order->get_total() * 100),
 					'description' => 'WCPagarmePixPayment',
 					'quantity' => 1
 				]
 			],
-			'customer' => [ 
-				'name' => trim( $order->get_meta( '_billing_first_name' ) . ' ' . $order->get_meta( '_billing_last_name' ) ),
-				'email' => $order->get_meta( '_billing_email' ),
+			'customer' => [
+				'name' => trim($order->get_meta('_billing_first_name') . ' ' . $order->get_meta('_billing_last_name')),
+				'email' => $order->get_meta('_billing_email'),
 				'type' => 'individual',
 			],
-			'payments' => [ 
-				[ 
+			'payments' => [
+				[
 					'payment_method' => 'pix',
-					'pix' => [ 
-						'expires_at' => date( 'Y-m-d H:i:s', strtotime( '+' . $this->gateway->expiration_days . ' days ' . $this->gateway->expiration_hours . ' hours', current_time( 'timestamp' ) ) ),
+					'pix' => [
+						'expires_at' => date('Y-m-d H:i:s', strtotime('+' . $this->gateway->expiration_days . ' days ' . $this->gateway->expiration_hours . ' hours', current_time('timestamp'))),
 					]
 				]
 			],
 			'code' => $order->get_id()
 		);
 
-		$cellphone = $order->get_meta( '_billing_cellphone' );
+		$cellphone = $order->get_meta('_billing_cellphone');
 		// Cell Phone.
-		if ( ! empty( $cellphone ) ) {
-			$cellphone = $this->only_numbers( $cellphone );
+		if (! empty($cellphone)) {
+			$cellphone = $this->only_numbers($cellphone);
 
 			$data['customer']['phones']['mobile_phone'] = array(
 				'country_code' => '55',
-				'area_code' => substr( $cellphone, 0, 2 ),
-				'number' => substr( $cellphone, 2 ),
+				'area_code' => substr($cellphone, 0, 2),
+				'number' => substr($cellphone, 2),
 			);
 		}
 
-		$phone = $order->get_meta( '_billing_phone' );
+		$phone = $order->get_meta('_billing_phone');
 		// Phone.
-		if ( ! empty( $phone ) ) {
-			$phone = $this->only_numbers( $phone );
+		if (! empty($phone)) {
+			$phone = $this->only_numbers($phone);
 
 			$data['customer']['phones']['home_phone'] = array(
 				'country_code' => '55',
-				'area_code' => substr( $phone, 0, 2 ),
-				'number' => substr( $phone, 2 ),
+				'area_code' => substr($phone, 0, 2),
+				'number' => substr($phone, 2),
 			);
 		}
 
-		if ( ! isset( $data['customer']['phones']['home_phone'] ) && ! isset( $data['customer']['phones']['mobile_phone'] ) ) {
-			wc_add_notice( 'É obrigatório preencher o campo celular ou campo telefone.', 'error' );
+		if (! isset($data['customer']['phones']['home_phone']) && ! isset($data['customer']['phones']['mobile_phone'])) {
+			wc_add_notice('É obrigatório preencher o campo celular ou campo telefone.', 'error');
 			return null;
 		}
 
-		if ( empty( $order->get_meta( '_billing_cpf' ) ) && empty( $order->get_meta( '_billing_cnpj' ) ) ) {
-			wc_add_notice( 'É obrigatório preencher o campo CPF ou CNPJ para pagamento em PIX.', 'error' );
+		if (empty($order->get_meta('_billing_cpf')) && empty($order->get_meta('_billing_cnpj'))) {
+			wc_add_notice('É obrigatório preencher o campo CPF ou CNPJ para pagamento em PIX.', 'error');
 			return null;
 		}
 
 		// Set the document number.
-		if ( class_exists( 'Extra_Checkout_Fields_For_Brazil' ) ) {
-			$wcbcf_settings = get_option( 'wcbcf_settings' );
+		if (class_exists('Extra_Checkout_Fields_For_Brazil')) {
+			$wcbcf_settings = get_option('wcbcf_settings');
 			$person_type = (string) $wcbcf_settings['person_type'];
-			if ( '0' !== $person_type ) {
-				if ( ( '1' === $person_type && '1' === $order->get_meta( '_billing_persontype' ) ) || '2' === $person_type ) {
-					if ( ! $this->cpfValidator( $order->get_meta( '_billing_cpf' ) ) ) {
-						wc_add_notice( 'CPF Inválido.', 'error' );
+			if ('0' !== $person_type) {
+				if (('1' === $person_type && '1' === $order->get_meta('_billing_persontype')) || '2' === $person_type) {
+					if (! $this->cpfValidator($order->get_meta('_billing_cpf'))) {
+						wc_add_notice('CPF Inválido.', 'error');
 						return null;
 					}
-					$data['customer']['document'] = $this->only_numbers( $order->get_meta( '_billing_cpf' ) );
+					$data['customer']['document'] = $this->only_numbers($order->get_meta('_billing_cpf'));
 					$data['customer']['type'] = 'individual';
 					$data['customer']['document_type'] = 'CPF';
 				}
 
-				if ( ( '1' === $person_type && '2' === $order->get_meta( '_billing_persontype' ) ) || '3' === $person_type ) {
-					$data['customer']['name'] = $order->get_meta( '_billing_company' );
+				if (('1' === $person_type && '2' === $order->get_meta('_billing_persontype')) || '3' === $person_type) {
+					$data['customer']['name'] = $order->get_meta('_billing_company');
 					$data['customer']['type'] = 'company';
-					$data['customer']['document'] = $this->only_numbers( $order->get_meta( '_billing_cnpj' ) );
+					$data['customer']['document'] = $this->only_numbers($order->get_meta('_billing_cnpj'));
 					$data['customer']['document_type'] = 'CNPJ';
 				}
 			}
 		} else {
-			if ( ! empty( $order->get_meta( '_billing_cpf' ) ) ) {
-				if ( ! $this->cpfValidator( $order->get_meta( '_billing_cpf' ) ) ) {
-					wc_add_notice( 'CPF Inválido.', 'error' );
+			if (! empty($order->get_meta('_billing_cpf'))) {
+				if (! $this->cpfValidator($order->get_meta('_billing_cpf'))) {
+					wc_add_notice('CPF Inválido.', 'error');
 					return null;
 				}
-				$data['customer']['document'] = $this->only_numbers( $order->get_meta( '_billing_cpf' ) );
+				$data['customer']['document'] = $this->only_numbers($order->get_meta('_billing_cpf'));
 			}
-			if ( ! empty( $order->get_meta( '_billing_cnpj' ) ) ) {
-				$data['customer']['name'] = $order->get_meta( '_billing_company' );
-				$data['customer']['document'] = $this->only_numbers( $order->get_meta( '_billing_cnpj' ) );
+			if (! empty($order->get_meta('_billing_cnpj'))) {
+				$data['customer']['name'] = $order->get_meta('_billing_company');
+				$data['customer']['document'] = $this->only_numbers($order->get_meta('_billing_cnpj'));
 			}
 		}
 
 		// Set the customer gender.
-		if ( ! empty( $order->get_meta( '_billing_sex' ) ) ) {
-			$data['customer']['gender'] = strtoupper( substr( $order->get_meta( '_billing_sex' ), 0, 1 ) ) == 'M' ? 'male' : 'female';
+		if (! empty($order->get_meta('_billing_sex'))) {
+			$data['customer']['gender'] = strtoupper(substr($order->get_meta('_billing_sex'), 0, 1)) == 'M' ? 'male' : 'female';
 		}
 
 		// Set the customer birthdate.
-		if ( ! empty( $order->get_meta( '_billing_birthdate' ) ) ) {
-			$birthdate = explode( '/', $order->get_meta( '_billing_birthdate' ) );
+		if (! empty($order->get_meta('_billing_birthdate'))) {
+			$birthdate = explode('/', $order->get_meta('_billing_birthdate'));
 
 			$data['customer']['birthdate'] = $birthdate[1] . '-' . $birthdate[0] . '-' . $birthdate[2];
 		}
 
 		// Add filter for Third Party plugins.
-		return apply_filters( 'wc_pagarme_pix_payment_transaction_data', $data, $order );
+		return apply_filters('wc_pagarme_pix_payment_transaction_data', $data, $order);
 	}
 
-	public function process_regular_payment( $order_id ) {
-		$order = wc_get_order( $order_id );
+	public function process_regular_payment($order_id)
+	{
+		$order = wc_get_order($order_id);
 
-		if ( $this->gateway->is_debug() ) {
-			$this->gateway->log->add( $this->gateway->id, 'API PagarmePix: Init process payment' );
+		if ($this->gateway->is_debug()) {
+			$this->gateway->log->add($this->gateway->id, 'API PagarmePix: Init process payment');
 		}
 
-		if ( ! is_plugin_active( 'woocommerce-extra-checkout-fields-for-brazil/woocommerce-extra-checkout-fields-for-brazil.php' ) ) {
-			wc_add_notice( 'O <strong>CPF é obrigatório</strong> para V5 da Pagarme, instale o plugin <strong>Brazilian Market on WooCommerce</strong> para ter o campo CPF no checkout.', 'error' );
+		if (! is_plugin_active('woocommerce-extra-checkout-fields-for-brazil/woocommerce-extra-checkout-fields-for-brazil.php')) {
+			wc_add_notice('O <strong>CPF é obrigatório</strong> para V5 da Pagarme, instale o plugin <strong>Brazilian Market on WooCommerce</strong> para ter o campo CPF no checkout.', 'error');
 
 			return array(
 				'result' => 'fail',
 			);
 		}
 
-		$data = $this->generate_transaction_data( $order );
+		$data = $this->generate_transaction_data($order);
 
-		if ( $this->gateway->is_debug() ) {
-			$this->gateway->log->add( $this->gateway->id, 'API PagarmePix: Send pagarme data:' . print_r( $data, true ) );
+		if ($this->gateway->is_debug()) {
+			$this->gateway->log->add($this->gateway->id, 'API PagarmePix: Send pagarme data:' . print_r($data, true));
 		}
 
-		if ( $data == null ) {
+		if ($data == null) {
 			return array(
 				'result' => 'fail',
 			);
 		}
 
-		$transaction = $this->do_transaction( $order, json_encode( $data ) );
+		$transaction = $this->do_transaction($order, json_encode($data));
 
-		if ( isset( $transaction['errors'] ) ) {
-			foreach ( $transaction['errors'] as $error ) {
-				wc_add_notice( $error['message'], 'error' );
+		if (isset($transaction['errors'])) {
+			foreach ($transaction['errors'] as $error) {
+				wc_add_notice($error['message'], 'error');
 			}
 
 			return array(
@@ -180,60 +185,67 @@ class PagarmeApiV5 extends PagarmeApi {
 			);
 		} else {
 
-			if ( extension_loaded( 'mbstring' ) && version_compare( phpversion(), "7.4", ">=" ) ) {
-				$upload = wp_upload_dir();
-				$upload_folder = sprintf( '%s/%s/qr-codes/', $upload['basedir'], \WC_PAGARME_PIX_PAYMENT_DIR_NAME );
-				$upload_url = sprintf( '%s/%s/qr-codes/', $upload['baseurl'], \WC_PAGARME_PIX_PAYMENT_DIR_NAME );
+			if (extension_loaded('mbstring') && version_compare(phpversion(), "7.4", ">=")) {
+				$is_base64 = $this->gateway->is_save_as_base64();
+				if ($is_base64) {
+					$qrcode_as_base64 = (new QRCode)->render($transaction['charges'][0]['last_transaction']['qr_code']);
+				} else {
+					$upload = wp_upload_dir();
+					$upload_folder = sprintf('%s/%s/qr-codes/', $upload['basedir'], \WC_PAGARME_PIX_PAYMENT_DIR_NAME);
+					$upload_url = sprintf('%s/%s/qr-codes/', $upload['baseurl'], \WC_PAGARME_PIX_PAYMENT_DIR_NAME);
 
-				if ( ! file_exists( $upload_folder ) ) {
-					wp_mkdir_p( $upload_folder );
+					if (! file_exists($upload_folder)) {
+						wp_mkdir_p($upload_folder);
+					}
+
+					$qrcode_file_name = date('Ymd', strtotime(current_time('mysql'))) . $transaction['id'] . '.png';
+					(new QRCode)->render($transaction['charges'][0]['last_transaction']['qr_code'], $upload_folder . $qrcode_file_name);
 				}
 
-				$qrcode_file_name = date( 'Ymd', strtotime( current_time( 'mysql' ) ) ) . $transaction['id'] . '.png';
-				( new QRCode )->render( $transaction['charges'][0]['last_transaction']['qr_code'], $upload_folder . $qrcode_file_name );
-
-				$order->update_meta_data( '_wc_pagarme_pix_payment_qr_code_image', $upload_url . $qrcode_file_name );
+				$order->update_meta_data('_wc_pagarme_pix_payment_qr_code_image', $is_base64 ? $qrcode_as_base64 : ($upload_url . $qrcode_file_name));
 			} else {
-				$order->update_meta_data( '_wc_pagarme_pix_payment_qr_code_image', sprintf( "%s", $transaction['charges'][0]['last_transaction']['qr_code_url'] ) );
+				$order->update_meta_data('_wc_pagarme_pix_payment_qr_code_image', sprintf("%s", $transaction['charges'][0]['last_transaction']['qr_code_url']));
 			}
 
-			$order->update_meta_data( '_wc_pagarme_pix_payment_qr_code', $transaction['charges'][0]['last_transaction']['qr_code'] );
-			$order->update_meta_data( '_wc_pagarme_pix_payment_expiration_date', date( 'Y-m-d H:i:s', strtotime( '+' . $this->gateway->expiration_days . ' days ' . $this->gateway->expiration_hours . ' hours', current_time( 'timestamp' ) ) ) );
-			$order->update_meta_data( '_wc_pagarme_pix_payment_expiration_days', $this->gateway->expiration_days );
-			$order->update_meta_data( '_wc_pagarme_pix_payment_transaction_id', $transaction['id'] );
-			$order->update_meta_data( '_wc_pagarme_pix_payment_paid', 'no' );
+			$order->update_meta_data('_wc_pagarme_pix_payment_qr_code', $transaction['charges'][0]['last_transaction']['qr_code']);
+			$order->update_meta_data('_wc_pagarme_pix_payment_expiration_date', date('Y-m-d H:i:s', strtotime('+' . $this->gateway->expiration_days . ' days ' . $this->gateway->expiration_hours . ' hours', current_time('timestamp'))));
+			$order->update_meta_data('_wc_pagarme_pix_payment_expiration_days', $this->gateway->expiration_days);
+			$order->update_meta_data('_wc_pagarme_pix_payment_transaction_id', $transaction['id']);
+			$order->update_meta_data('_wc_pagarme_pix_payment_paid', 'no');
 
 			$order->save();
 
-			$this->process_order_status( $order, $transaction['status'] );
+			$this->process_order_status($order, $transaction['status']);
 
 			// Empty the cart.
-			if ( method_exists( WC()->cart, 'empty_cart' ) ) {
+			if (method_exists(WC()->cart, 'empty_cart')) {
 				WC()->cart->empty_cart();
 			}
 
 			// Redirect to thanks page.
 			return array(
 				'result' => 'success',
-				'redirect' => $this->gateway->get_return_url( $order ),
+				'redirect' => $this->gateway->get_return_url($order),
 			);
 		}
 	}
 
-	public function check_fingerprint( $ipn_response ) {
-		if ( isset( $ipn_response['id'] ) ) {
+	public function check_fingerprint($ipn_response)
+	{
+		if (isset($ipn_response['id'])) {
 			return true;
 		}
 
 		return false;
 	}
 
-	public function process_successful_ipn( $posted ) {
-		$posted = wp_unslash( $posted );
+	public function process_successful_ipn($posted)
+	{
+		$posted = wp_unslash($posted);
 
-		if ( $this->gateway->is_debug() ) {
-			$this->gateway->log->add( $this->gateway->id, 'Sucesso: ID = ' . $posted['id'] );
-			$this->gateway->log->add( $this->gateway->id, 'Sucesso: OrderID = ' . $posted['data']['order']['id'] );
+		if ($this->gateway->is_debug()) {
+			$this->gateway->log->add($this->gateway->id, 'Sucesso: ID = ' . $posted['id']);
+			$this->gateway->log->add($this->gateway->id, 'Sucesso: OrderID = ' . $posted['data']['order']['id']);
 		}
 
 		$args = array(
@@ -243,41 +255,42 @@ class PagarmeApiV5 extends PagarmeApi {
 			'meta_compare' => '=',
 		);
 
-		$orders = wc_get_orders( $args );
+		$orders = wc_get_orders($args);
 
-		if ( empty( $orders ) ) {
-			$this->gateway->log->add( $this->gateway->id, 'ERRO: Nenhum internalId = ' . $posted['internalId'] );
+		if (empty($orders)) {
+			$this->gateway->log->add($this->gateway->id, 'ERRO: Nenhum internalId = ' . $posted['internalId']);
 			return;
 		}
 
-		$order = reset( $orders );
-		$status = sanitize_text_field( $posted['data']['status'] );
+		$order = reset($orders);
+		$status = sanitize_text_field($posted['data']['status']);
 
-		if ( $order && $posted['data']['payment_method'] == 'pix' ) {
+		if ($order && $posted['data']['payment_method'] == 'pix') {
 
-			if ( $this->gateway->is_debug() ) {
-				$this->gateway->log->add( $this->gateway->id, print_r( $posted, true ) );
+			if ($this->gateway->is_debug()) {
+				$this->gateway->log->add($this->gateway->id, print_r($posted, true));
 			}
-			$this->process_order_status( $order, $status );
+			$this->process_order_status($order, $status);
 		}
 	}
 
-	public function ipn_handler() {
+	public function ipn_handler()
+	{
 		@ob_clean();
 
-		$post = file_get_contents( 'php://input' );
+		$post = file_get_contents('php://input');
 
-		if ( $this->gateway->is_debug() ) {
-			$this->gateway->log->add( $this->gateway->id, 'Retornou um POSTBACK' );
-			$this->gateway->log->add( $this->gateway->id, 'Response' . print_r( $post, true ) );
+		if ($this->gateway->is_debug()) {
+			$this->gateway->log->add($this->gateway->id, 'Retornou um POSTBACK');
+			$this->gateway->log->add($this->gateway->id, 'Response' . print_r($post, true));
 		}
 
-		$ipn_response = ! empty( $post ) ? json_decode( $post, true ) : false;
+		$ipn_response = ! empty($post) ? json_decode($post, true) : false;
 
-		if ( $ipn_response && $this->check_fingerprint( $ipn_response ) ) {
-			header( 'HTTP/1.1 200 OK' );
+		if ($ipn_response && $this->check_fingerprint($ipn_response)) {
+			header('HTTP/1.1 200 OK');
 
-			$this->process_successful_ipn( $ipn_response );
+			$this->process_successful_ipn($ipn_response);
 
 			wp_send_json(
 				array(
@@ -288,7 +301,7 @@ class PagarmeApiV5 extends PagarmeApi {
 			exit;
 		} else {
 
-			wp_die( esc_html__( 'Pagar.me PIX Request Failure', 'wc-pagarme-pix-payment' ), '', array( 'response' => 401 ) );
+			wp_die(esc_html__('Pagar.me PIX Request Failure', 'wc-pagarme-pix-payment'), '', array('response' => 401));
 		}
 	}
 }

--- a/templates/html-woocommerce-thank-you-page.php
+++ b/templates/html-woocommerce-thank-you-page.php
@@ -23,7 +23,7 @@ $copy_button_html = ob_get_clean();
 ob_start();
 ?>
 <div id="qr-code-container" style="text-align: center;">
-    <div id="qr-code-loader" style="display: flex; align-items: center; justify-content: center; flex-direction: column;">
+    <div id="qr-code-loader" style="display: flex; align-items: center; justify-content: center; flex-direction: column; padding: 16px;">
         <svg id="spinner" style="margin-bottom: 10px;" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M12 2.25V4.75M12 18V22M5.75 12H2.25M21.25 12H19.75M18.4571 18.4571L17.75 17.75M18.6642 5.41579L17.25 6.83M4.92157 19.0784L7.75 16.25M5.12868 5.20868L7.25 7.33" stroke="#1E2328" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
         </svg>
@@ -36,10 +36,8 @@ ob_start();
         const qrCodeImage = document.getElementById("qr-code-image");
         const loader = document.getElementById("qr-code-loader");
         const qrCodeUrl = "<?php echo esc_js($qr_code_image); ?>";
-        const maxAttempts = 5;
+        const maxAttempts = 15;
         let attemptCount = 0;
-
-        console.log("QR Code URL: " + qrCodeUrl);
 
         function checkImage(url, callback) {
             const img = new Image();
@@ -69,9 +67,9 @@ ob_start();
                     loader.style.display = "none";
                     console.log("QR Code image displayed.");
                 } else {
-                    console.log("QR Code image not available, retrying in 2 seconds...");
+                    console.log("QR Code image not available, retrying in 3 seconds...");
                     attemptCount++;
-                    setTimeout(loadQrCode, 2000); // Tenta novamente após 2 segundos
+                    setTimeout(loadQrCode, 3000); // Tenta novamente após 3 segundos
                 }
             });
         }

--- a/templates/html-woocommerce-thank-you-page.php
+++ b/templates/html-woocommerce-thank-you-page.php
@@ -29,7 +29,7 @@ ob_start();
         </svg>
         Carregando QR Code...
     </div>
-    <img id="qr-code-image" src="" alt="QR Code" style="display:none;" />
+    <img id="qr-code-image" src="<?php echo $qr_code_image ?>" alt="QR Code" style="display:none;" />
 </div>
 <script>
     document.addEventListener("DOMContentLoaded", function() {

--- a/templates/html-woocommerce-thank-you-page.php
+++ b/templates/html-woocommerce-thank-you-page.php
@@ -24,8 +24,8 @@ ob_start();
 ?>
 <div id="qr-code-container" style="text-align: center;">
     <div id="qr-code-loader" style="display: flex; align-items: center; justify-content: center; flex-direction: column;">
-        <svg id="spinner" width="50" height="50" viewBox="0 0 50 50" style="margin-bottom: 10px;">
-            <circle cx="25" cy="25" r="20" stroke="#000" stroke-width="5" fill="none" />
+        <svg id="spinner" style="margin-bottom: 10px;" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M12 2.25V4.75M12 18V22M5.75 12H2.25M21.25 12H19.75M18.4571 18.4571L17.75 17.75M18.6642 5.41579L17.25 6.83M4.92157 19.0784L7.75 16.25M5.12868 5.20868L7.25 7.33" stroke="#1E2328" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
         </svg>
         Carregando QR Code...
     </div>

--- a/templates/html-woocommerce-thank-you-page.php
+++ b/templates/html-woocommerce-thank-you-page.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @var \WC_Order $order
  */
@@ -21,7 +22,63 @@ $copy_button_html = ob_get_clean();
 
 ob_start();
 ?>
-<img src="<?php echo $qr_code_image; ?>" />
+<div id="qr-code-container" style="text-align: center;">
+    <div id="qr-code-loader" style="display: flex; align-items: center; justify-content: center; flex-direction: column;">
+        <svg id="spinner" width="50" height="50" viewBox="0 0 50 50" style="margin-bottom: 10px;">
+            <circle cx="25" cy="25" r="20" stroke="#000" stroke-width="5" fill="none" />
+        </svg>
+        Carregando QR Code...
+    </div>
+    <img id="qr-code-image" src="" alt="QR Code" style="display:none;" />
+</div>
+<script>
+    document.addEventListener("DOMContentLoaded", function() {
+        const qrCodeImage = document.getElementById("qr-code-image");
+        const loader = document.getElementById("qr-code-loader");
+        const qrCodeUrl = "<?php echo esc_js($qr_code_image); ?>";
+        const maxAttempts = 5;
+        let attemptCount = 0;
+
+        console.log("QR Code URL: " + qrCodeUrl);
+
+        function checkImage(url, callback) {
+            const img = new Image();
+            img.onload = () => {
+                console.log("QR Code image loaded successfully.");
+                callback(true);
+            };
+            img.onerror = () => {
+                console.log("Failed to load QR Code image.");
+                callback(false);
+            };
+            img.src = url;
+        }
+
+        function loadQrCode() {
+            if (attemptCount >= maxAttempts) {
+                console.log("Max attempts reached. QR Code image could not be loaded.");
+                loader.innerText = "Falha ao carregar o QR Code. Por favor, tente novamente mais tarde.";
+                return;
+            }
+
+            console.log("Attempting to load QR Code image... Attempt #" + (attemptCount + 1));
+            checkImage(qrCodeUrl, function(isAvailable) {
+                if (isAvailable) {
+                    qrCodeImage.src = qrCodeUrl;
+                    qrCodeImage.style.display = "block";
+                    loader.style.display = "none";
+                    console.log("QR Code image displayed.");
+                } else {
+                    console.log("QR Code image not available, retrying in 2 seconds...");
+                    attemptCount++;
+                    setTimeout(loadQrCode, 2000); // Tenta novamente após 2 segundos
+                }
+            });
+        }
+
+        loadQrCode();
+    });
+</script>
 <?php
 $qr_code_html = ob_get_clean();
 
@@ -144,6 +201,16 @@ $qr_code_html = ob_get_clean();
         }
     }
 
+    @keyframes spin {
+        0% {
+            transform: rotate(0deg);
+        }
+
+        100% {
+            transform: rotate(360deg);
+        }
+    }
+
     #successAnimationCircle {
         stroke-dasharray: 151px 151px;
         stroke: #007bff;
@@ -177,6 +244,11 @@ $qr_code_html = ob_get_clean();
     #successAnimation.animated #successAnimationResult {
         -webkit-animation: 0.3s linear 0.9s both fadeIn;
         animation: 0.3s linear 0.9s both fadeIn;
+    }
+
+    #spinner {
+        -webkit-animation: spin 1s linear infinite;
+        animation: spin 1s linear infinite;
     }
 </style>
 <div class="text-center">


### PR DESCRIPTION
# Adiciona carregamento dinâmico de QR Code na página de agradecimento do WooCommerce e suporte para salvar QR Code como Base64

## Descrição
Este pull request aprimora o carregamento do QR Code na página de agradecimento do WooCommerce, garantindo compatibilidade com S3 e introduzindo a opção de salvar o QR Code como uma string Base64. Essa abordagem elimina a necessidade de transferir dados adicionais do servidor para o cliente, melhorando o desempenho e a experiência do usuário.

## Alterações realizadas
- **Carregamento dinâmico com spinner:** Resolvido o problema de exibição de imagens quebradas ao utilizar S3, adicionando um indicador de carregamento durante o processo.
- **QR Code como Base64:** 
  - Criado um campo para armazenar a versão Base64 do QR Code.
  - Incluído suporte para salvar o QR Code diretamente como Base64 na API.
  - Alterações na lógica de carregamento para exibir o QR Code a partir da string Base64, quando disponível.
- **Configuração no aplicativo:** 
  - Adicionado um novo campo nas configurações do aplicativo para habilitar o armazenamento e uso do QR Code como Base64.
  - Implementadas configurações necessárias para garantir o funcionamento adequado.

## Impacto
- **Mudanças de comportamento:** 
  - QR Code carregado dinamicamente com spinner em casos de uso com S3.
  - Nova opção para carregar o QR Code como Base64 diretamente, evitando requisições adicionais.
- **Dependências afetadas:** Nenhuma identificada.
- **Compatibilidade:** Não há mudanças que quebram funcionalidades existentes.
- **Possíveis implicações de desempenho:** Melhoria no desempenho ao reduzir o número de transferências de dados com o uso de Base64.

## Testes realizados
- Validação do carregamento dinâmico com spinner em ambientes com S3.
- Teste da funcionalidade de QR Code como Base64, incluindo a ativação e desativação nas configurações.
- Simulação de cenários com e sem a opção Base64 habilitada, garantindo o correto funcionamento em ambos.
- Testes em navegadores modernos e diferentes dispositivos para validar compatibilidade e usabilidade.

## Como testar
1. Acesse as configurações do aplicativo no painel do WooCommerce.
2. Habilite a opção para salvar o QR Code como Base64.
3. Finalize uma compra no WooCommerce para acessar a página de agradecimento.
4. Verifique:
   - O QR Code é exibido corretamente, seja a partir da string Base64 ou do carregamento dinâmico com spinner.
   - Em ambientes com S3, não há exibição de imagens quebradas durante o carregamento.

Aguardando feedback para ajustes e melhorias! 🚀
